### PR TITLE
Fix for display user role issue

### DIFF
--- a/src/app/reducers/login.reducer.ts
+++ b/src/app/reducers/login.reducer.ts
@@ -13,7 +13,8 @@ export function userReducer(state: UserState = initialUserState, action: LoginAc
       return {
         ...state,
         userName: action.payload.userName,
-        name: action.payload.name
+        name: action.payload.name,
+        isAdmin: action.payload.isAdmin
       };
     
     case LoginActions.REMOVE_USER:


### PR DESCRIPTION
- The user role `operator` or `Admin` should be displayed correctly in the drawer panel.

![image](https://user-images.githubusercontent.com/11648370/73183573-06bdc080-4141-11ea-9732-940c7e9b1bfb.png)
